### PR TITLE
Ml commands title

### DIFF
--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -359,22 +359,19 @@ def list_model_commands(args):
     
     info = utils.load_description(model)
 
-    msg = "The model '{}' "
-    if 'title' not in info['meta']:
-        title = None
-        msg_warning = "{}warning: Malformed {} file: missing meta -> title\n"
-        msg_warning = msg_warning.format(APPX, DESC_YML)
-        print(msg_warning, file=sys.stderr)
-    else:
+    try:
         title = re.sub("\.$", "", info['meta']['title'])
         lc = lambda s: s[:1].lower() + s[1:] if s else ''
         title = lc(title)
-        msg += "({}) "
-
-    msg += "supports the following commands:"
-    msg = msg.format(model, title)
-    msg = textwrap.fill(msg, width=75)
-    print(msg + "\n")
+        msg = "The model '{}' ({}) supports the following commands:"
+        msg = msg.format(model, title)
+        msg = textwrap.fill(msg, width=75)
+        print(msg + "\n")
+    except KeyError as e:
+        msg_warning = "{}error: Malformed {} file: missing {}"
+        msg_warning = msg_warning.format(APPX, DESC_YML, str(e))
+        print(msg_warning, file=sys.stderr)
+        sys.exit(1)
 
     # TODO Separate each  command with empty line.
     

--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -359,10 +359,16 @@ def list_model_commands(args):
     
     info = utils.load_description(model)
 
-    title = re.sub("\.$", "", info['meta']['title'])
-    lc = lambda s: s[:1].lower() + s[1:] if s else ''
-    title = lc(title)
-    msg = "The model '{}' ({}) supports the following commands:"
+    msg = "The model '{}' "
+    if 'title' not in info['meta']:
+        title = None
+    else:
+        title = re.sub("\.$", "", info['meta']['title'])
+        lc = lambda s: s[:1].lower() + s[1:] if s else ''
+        title = lc(title)
+        msg += "({}) "
+
+    msg += "supports the following commands:"
     msg = msg.format(model, title)
     msg = textwrap.fill(msg, width=75)
     print(msg + "\n")

--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -362,6 +362,9 @@ def list_model_commands(args):
     msg = "The model '{}' "
     if 'title' not in info['meta']:
         title = None
+        msg_warning = "{}warning: Malformed {} file: missing meta -> title\n"
+        msg_warning = msg_warning.format(APPX, DESC_YML)
+        print(msg_warning, file=sys.stderr)
     else:
         title = re.sub("\.$", "", info['meta']['title'])
         lc = lambda s: s[:1].lower() + s[1:] if s else ''


### PR DESCRIPTION
I've submitted 3 commits for different results:
simonzhaoms/mlhub@bda5e0e8a592bec48c54b1c743708d70533eff7b just ignore the title.
```
$ ml commands dogs-cats
The model 'dogs-cats' supports the following commands:

demo: apply the model to a sample dataset
display: display a graphical representaiton of the model
print: print a textual summary of the model
score: apply the model to a supplied dataset and show result via shiny
train: build a new model on your own image data with training set and validation set
  provided

Once configured the demo can be run:

  $ ml demo dogs-cats
```
simonzhaoms/mlhub@3b7a01e292b88450eb633cb93cefc2bb8dc9c56e ignore the title and print a warning.
```
$ ml commands dogs-cats
mlhub: warning: Malformed DESCRIPTION.yml file: missing meta -> title

The model 'dogs-cats' supports the following commands:

demo: apply the model to a sample dataset
display: display a graphical representaiton of the model
print: print a textual summary of the model
score: apply the model to a supplied dataset and show result via shiny
train: build a new model on your own image data with training set and validation set
  provided

Once configured the demo can be run:

  $ ml demo dogs-cats
```
simonzhaoms/mlhub@7f8df7034b4f831ad676633afe87c6d3343f01ce capture the exception and exit.
```
$ ml commands dogs-cats
mlhub: error: Malformed DESCRIPTION.yml file: missing 'title'
```