### PR TITLE
Check DISPLAY for graphic commands

### DIFF
--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -487,6 +487,15 @@ def dispatch(args):
     
     desc = utils.load_description(model)
 
+    # check if cmd needs to use graphic display indicated in DESCRIPTION.yaml
+
+    if 'display' in desc['meta'] and cmd in desc['meta']['display'] and 'DISPLAY' not in os.environ:
+        msg = "Graphic display not available for command '{}'. Continue [y/N]? "
+        msg = msg.format(cmd)
+        sys.stdout.write(msg)
+        choice = input().lower()
+        if choice != 'y': sys.exit(1)
+
     # Obtain the default/chosen language for the package.
 
     lang = desc["meta"]["languages"]


### PR DESCRIPTION
Then model developer only need to specify which commands need to use graphic display, so checking isn't needed in the model code any more.

Code such as in `rain-tomorrow/display.R` below should be removed:
```R
# If a display is available then make use of it.

if (Sys.getenv("DISPLAY") != "")
{
} else
{
}
```