### PR TITLE
Make sure model commands are suggested by the oder in DESCRIPTION.yaml

### DIFF
--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -395,12 +395,12 @@ def list_model_commands(args):
     #     print(c)
     #     print(c['script'])
 
-    yaml.dump(info['commands'], sys.stdout, default_flow_style = False)
+    yaml.dump(dict(info['commands']), sys.stdout, default_flow_style = False)
 
     # Suggest next step.
     
     if not args.quiet:
-        utils.print_next_step('commands', model=model)
+        utils.print_next_step('commands', description=info, model=model)
 
 #-----------------------------------------------------------------------
 # CONFIGURE

--- a/mlhub/constants.py
+++ b/mlhub/constants.py
@@ -78,8 +78,9 @@ COMMANDS = {
     # 'next': specify the next possible commands after the command.
     #         There can be groups of next commands for different scenarios,
     #         like the command 'installed'.
-    #         Next step order: available, install, readme, configure,
-    #                          commands, demo.
+    #         Next step order: 'available', 'install', 'readme', 'configure',
+    #                          'commands' and commands by the order in the
+    #                          model's DESCRIPTION.yaml
     # 'confirm': Maybe used for collecting user's confirmation.
     # 'argument': possible argument for the command used by argparse.
 
@@ -146,7 +147,6 @@ COMMANDS = {
                'usage': "  commands   <model>   "
                         "List the commands supported by the model.",
                 'func': "list_model_commands",
-                'next': ['demo'],
         },
 
     'configure':

--- a/mlhub/utils.py
+++ b/mlhub/utils.py
@@ -31,6 +31,7 @@
 import os
 import sys
 import yaml
+import yamlordereddictloader
 import urllib.request
 import platform
 import subprocess
@@ -154,11 +155,11 @@ def load_description(model):
 
     desc = os.path.join(MLINIT, model, DESC_YAML)
     if os.path.exists(desc):
-        entry = yaml.load(open(desc))
+        entry = yaml.load(open(desc), Loader=yamlordereddictloader.Loader)
     else:
         desc = os.path.join(MLINIT, model, DESC_YML)
         if os.path.exists(desc):
-            entry = yaml.load(open(desc))
+            entry = yaml.load(open(desc), Loader=yamlordereddictloader.Loader)
         else:
             msg = "{}no '{}' found for '{}'."
             msg = msg.format(APPX, DESC_YAML, model)
@@ -292,7 +293,8 @@ def print_next_step(current, description={}, scenario=None, model=''):
         # Use the order in DESCRIPTION.yaml
 
         avail_cmds = list(description['commands'])
-        next_index = avail_cmds.index(current) + 1
+
+        next_index = avail_cmds.index(current) + 1 if current != 'commands' else 0
         if next_index < len(avail_cmds):
             next = avail_cmds[next_index]
             msg = dropdot(lower_first_letter(description['commands'][next]))

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,5 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     package_data={'.': ['LICENSE']},
     entry_points={'console_scripts': ['ml=mlhub:main']},
+    install_requires=['requests', 'pyyaml', 'yamlordereddictloader', ],
 )


### PR DESCRIPTION
Resolved issue #24 
1. use OrderedDict to preserve the order when loading .yaml file
2. specify dependency for required packages in setup.py