### PR TITLE
Fix 'ml commands' and nested description in DESCRIPTION.yaml

### DIFF
--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -389,7 +389,30 @@ def list_model_commands(args):
 
     for c in info['commands']:
         print("\n  $ {} {} {}".format(CMD, c, model))
-        print("    " + info['commands'][c])
+
+        c_meta = info['commands'][c]
+        if type(c_meta) is str:
+            print("    " + c_meta)
+        else:
+            # Handle malformed DESCRIPTION.yaml like
+            # --
+            # commands:
+            #   print:
+            #     description: print a textual summary of the model
+            #   score:
+            #     equired: the name of a CSV file containing a header and 6 columns
+            #     description: apply the model to a supplied dataset
+
+            desc = c_meta.get('description', None)
+            if desc is not None:
+                print("    " + desc)
+
+            c_meta = {k:c_meta[k] for k in c_meta if k != 'description'}
+            if len(c_meta) > 0:
+                msg = yaml.dump(c_meta, default_flow_style=False)
+                msg = msg.split('\n')
+                msg = ["    " + ele for ele in msg]
+                print('\n'.join(msg), end='')
 
     # Suggest next step.
     

--- a/mlhub/utils.py
+++ b/mlhub/utils.py
@@ -304,8 +304,27 @@ def print_next_step(current, description={}, scenario=None, model=''):
         next_index = avail_cmds.index(current) + 1 if current != 'commands' else 0
         if next_index < len(avail_cmds):
             next = avail_cmds[next_index]
-            msg = dropdot(lower_first_letter(description['commands'][next]))
-            msg = "\nTo " + msg + ":\n\n  $ {} {} {}"
+            next_meta = description['commands'][next]
+
+            if type(next_meta) is str:
+                msg = dropdot(lower_first_letter(next_meta))
+            else:
+                # Handle malformed DESCRIPTION.yaml like
+                # --
+                # commands:
+                #   print:
+                #     description: print a textual summary of the model
+                #   score:
+                #     equired: the name of a CSV file containing a header and 6 columns
+                #     description: apply the model to a supplied dataset
+
+                msg = next_meta.pop('description', None)
+
+            if msg is not None:
+                msg = "\nTo " + msg
+            else:
+                msg = "You may try"
+            msg += ":\n\n  $ {} {} {}"
             msg = msg.format(CMD, next, model)
         else:
             msg = "\nThank you for exploring the '{}' model.".format(model)


### PR DESCRIPTION
Fix the issue #28: COMMANDS should fail gracefully with malformed DESCRIPTION.yaml