### PR TITLE
Add completion for model-specific commands

### DIFF
--- a/mlhub/bash_completion.d/ml.bash
+++ b/mlhub/bash_completion.d/ml.bash
@@ -3,38 +3,54 @@
 # [1] https://github.com/syncany/syncany/blob/master/gradle/bash/syncany.bash-completion
 
 # Gets the first non-option word of the command line, except the program name.
+# If none, the index would be the last word, and the first word would be empty.
 _mlhub_get_firstword() {
     local firstword i
 
-    firstword=
     for ((i = 1; i < ${#COMP_WORDS[@]}; ++i)); do
-	if [[ ${COMP_WORDS[i]} != -* ]]; then
+	if [[ ${COMP_WORDS[i]} != -* ]] &&
+	       [[ -n ${COMP_WORDS[i]} ]]; then
 	    firstword=${COMP_WORDS[i]}
 	    break
 	fi
     done
 
-    echo $firstword
+    echo $i $firstword
 }
 
-# Gets the last non-option word of the command line.
+# Gets the last non-option word of the command line,
+# except the program name and current word.
+# If none, the index would be zero, and the last word would be empty.
 _mlhub_get_lastword() {
-	local lastword i
+    local lastword i
 
-	lastword=
-	for ((i = 1; i < ${#COMP_WORDS[@]}; ++i)); do
-	    if [[ ${COMP_WORDS[i]} != -* ]] &&
-	       [[ -n ${COMP_WORDS[i]} ]] &&
-               [[ ${COMP_WORDS[i]} != $cur ]]; then
-	        lastword=${COMP_WORDS[i]}
-	    fi
+    for ((i = ${#COMP_WORDS[@]}; i > 0; i=i-1)); do
+	if [[ ${COMP_WORDS[i]} != -* ]] &&
+               [[ -n ${COMP_WORDS[i]} ]] &&
+	       [[ ${COMP_WORDS[i]} != ${cur} ]]; then
+	    lastword=${COMP_WORDS[i]}
+	    break
+	fi
+    done
+
+    echo $i $lastword
+}
+
+# Searches for available commands for all installed models.
+_mlhub_model_commands() {
+    local model_commands
+    local installed_models=$(ml installed --name-only)
+    for model in ${installed_models}; do
+	for cmd in $(ml commands --name-only ${model}); do
+	    model_commands+="${cmd} "
 	done
+    done
 
-	echo $lastword
+    echo $model_commands
 }
 
 _mlhub() {
-    local cur prev firstword lastword
+    local cur prev firstword i_firstword lastword i_lastword
     local complete_words    # possible completion list for current word
     local complete_options  # possible completion list for current option
 
@@ -52,8 +68,9 @@ _mlhub() {
 
     cur=${COMP_WORDS[COMP_CWORD]}      # current parameter
     prev=${COMP_WORDS[COMP_CWORD-1]}   # previous parameter
-    firstword=$(_mlhub_get_firstword)  # first non-option parameter
-    lastword=$(_mlhub_get_lastword)    # last non-option parameter
+
+    read i_firstword firstword < <(_mlhub_get_firstword) # first non-option parameter
+    read i_lastword lastword < <(_mlhub_get_lastword)    # last non-option parameter
 
     # available global commands
     global_commands="\
@@ -93,6 +110,7 @@ _mlhub() {
 
     commands_options="\
 	-h --help\
+        --name-only\
 	"
 
     configure_options="\
@@ -128,44 +146,64 @@ _mlhub() {
 	commands)
 	    complete_options="${commands_options}"
 
-	    local installed_model=$(ml installed --name-only)
+	    local installed_models=$(ml installed --name-only)
 
 	    # Only one model name is allowed
 	    local typed=0
-	    for model in ${installed_model}; do
+	    for model in ${installed_models}; do
 		if [[ "$model" == "$lastword" ]]; then
 		    typed=1
 		fi
 	    done
 
 	    if [[ $typed == 0 ]]; then
-		complete_words=("${installed_model}")
+		complete_words=("${installed_models}")
 	    fi
 	    ;;
 	configure)
 	    complete_options="${configure_options}"
-	    local installed_model=$(ml installed --name-only)
-	    complete_words=("${installed_model}")
+	    local installed_models=$(ml installed --name-only)
+	    complete_words=("${installed_models}")
 	    ;;
 	install)
 	    complete_options="${install_options}"
-	    local available_model=$(ml available --name-only)
-	    complete_words=("${available_model}")
+	    local available_models=$(ml available --name-only)
+	    complete_words=("${available_models}")
 	    ;;
 	readme)
 	    complete_options="${readme_options}"
-	    local installed_model=$(ml installed --name-only)
-	    complete_words=("${installed_model}")
+	    local installed_models=$(ml installed --name-only)
+	    complete_words=("${installed_models}")
 	    ;;
 	remove)
 	    complete_options="${remove_options}"
-	    local installed_model=$(ml installed --name-only)
-	    complete_words=("${installed_model}")
+	    local installed_models=$(ml installed --name-only)
+	    complete_words=("${installed_models}")
 	    ;;
 	*)
-	    complete_words="${global_commands}"
-	    complete_options="${global_options}"
-	    ;;
+	    if [[ ${COMP_CWORD} -le ${i_firstword} ]]; then
+
+		# For completion cases:
+		#   ml [TAB] firstword lastword
+		#   ml [TAB] firstword
+		#   ml first[TAB]word
+		#   ml [TAB]
+
+		complete_words="${global_commands}"
+		complete_words+="$(_mlhub_model_commands)"
+		complete_options="${global_options}"
+	    elif [[ ${i_lastword} -ge ${COMP_CWORD} ]] ||
+		     [[ ${i_firstword} -eq ${i_lastword} ]]; then
+
+		# For completion cases:
+		#   ml firstword [TAB] lastword
+		#   ml firstword [TAB]
+		#   ml first[TAB]word
+
+		local installed_models=$(ml installed --name-only)
+		complete_words=("${installed_models}")
+	    fi
+            ;;
     esac
 
     # Either display words or options, depending on the user input
@@ -176,5 +214,8 @@ _mlhub() {
     fi
 }
 
-# Hook completion function to ml
-complete -F _mlhub ml
+# Hook completion function to ml.
+# 
+# -o bashdefault -o default is used for `ml score dogs-cats [TAB]` to
+# complete directory names or file names.
+complete -F _mlhub -o bashdefault -o default ml

--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -391,6 +391,10 @@ def list_model_commands(args):
     
     info = utils.load_description(model)
 
+    if args.name_only:
+        print('\n'.join(list(info['commands'])))
+        return
+    
     msg = "The model '{}' "
     if 'title' not in info['meta']:
         title = None

--- a/mlhub/constants.py
+++ b/mlhub/constants.py
@@ -86,7 +86,7 @@ COMMANDS = {
 
     'available':
         {'description': "List the models available from the ML Hub",
-            'argument': {'--name-only': {'help': "List names only",
+            'argument': {'--name-only': {'help': "List available model names only",
                                          'action': "store_true"},
                         },
                'alias': ['avail'],
@@ -98,7 +98,7 @@ COMMANDS = {
 
     'installed':
         {'description': "List the locally installed models",
-            'argument': {'--name-only': {'help': "List names only",
+            'argument': {'--name-only': {'help': "List installed model names only",
                                          'action': "store_true"},
                         },
                'usage': "  installed            "
@@ -149,7 +149,10 @@ COMMANDS = {
 
     'commands':
         {'description': "List all of the commands supported by the model",
-            'argument': {'model': {}},
+            'argument': {'model': {},
+                         '--name-only': {'help': "List supported command names only",
+                                         'action': "store_true"},
+                        },
                'usage': "  commands   <model>   "
                         "List the commands supported by the model.",
                 'func': "list_model_commands",


### PR DESCRIPTION
Usage:
```console
$ ml d[TAB] [TAB]
demo     display  
$ ml d^C
$ ml score clothes-recommender ~/.mlhub/clothes-recommender/[TAB] [TAB]
configure.sh      demo.py           display.py        helpers.py        print.py          README.txt        
data/             DESCRIPTION.yaml  helpers_cntk.py   PARAMETERS.py     proc/             score.py          
$ ml score clothes-recommender ~/.mlhub/clothes-recommender/data/fashionTexture/[TAB] [TAB]
dotted/  leopard/ striped/
```