### PR TITLE
Put configuration for bash completion in post-install code of `pip install`

### DIFF
--- a/mlhub/bash_completion.d/ml.bash
+++ b/mlhub/bash_completion.d/ml.bash
@@ -49,6 +49,16 @@ _mlhub_model_commands() {
     echo $model_commands
 }
 
+# Return the completion words cached in $1
+_mlhub_cached_completion_words() {
+    local words=$(python -c "\
+import mlhub;\
+mlhub.utils.get_completion_list(mlhub.constants.$1)\
+    ")
+
+    echo ${words}
+}
+
 _mlhub() {
     local cur prev firstword i_firstword lastword i_lastword
     local complete_words    # possible completion list for current word
@@ -167,8 +177,7 @@ _mlhub() {
 	    ;;
 	install)
 	    complete_options="${install_options}"
-	    local available_models=$(ml available --name-only)
-	    complete_words=("${available_models}")
+	    complete_words=("$(_mlhub_cached_completion_words COMPLETION_MODELS)")
 	    ;;
 	readme)
 	    complete_options="${readme_options}"
@@ -190,7 +199,7 @@ _mlhub() {
 		#   ml [TAB]
 
 		complete_words="${global_commands}"
-		complete_words+="$(_mlhub_model_commands)"
+		complete_words+="$(_mlhub_cached_completion_words COMPLETION_COMMANDS)"
 		complete_options="${global_options}"
 	    elif [[ ${i_lastword} -ge ${COMP_CWORD} ]] ||
 		     [[ ${i_firstword} -eq ${i_lastword} ]]; then

--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -61,6 +61,8 @@ from mlhub.constants import (
     README,
     META_YML,
     DEBUG,
+    COMPLETION_MODELS,
+    COMPLETION_COMMANDS,
 )
 
 # The commands are implemented here in a logical order with each
@@ -94,6 +96,10 @@ def list_available(args):
 
     for info in meta:
         utils.print_meta_line(info)
+
+    # Update bash tab completion
+
+    utils.update_completion_list(COMPLETION_MODELS, {e['meta']['name'] for e in meta})
 
     # Suggest next step.
     
@@ -141,6 +147,9 @@ def list_installed(args):
     for p in models:
         entry = utils.load_description(p)
         utils.print_meta_line(entry)
+
+        # Update available commands for the model for fast bash tab completion.
+        utils.update_completion_list(COMPLETION_COMMANDS, set(entry['commands']))
 
     # Suggest next step.
     
@@ -203,6 +212,10 @@ def install_model(args):
         
             mlhub = utils.get_repo(args.mlhub)
             meta  = utils.get_repo_meta_data(mlhub)
+
+            # Update available models for fast bash tab completion.
+
+            utils.update_completion_list(COMPLETION_MODELS, {e['meta']['name'] for e in meta})
 
             # Find the first matching entry in the meta data.
 
@@ -300,6 +313,12 @@ def install_model(args):
     desc_yaml = os.path.join(path, DESC_YAML)
     if (not os.path.exists(desc_yaml)) and os.path.exists(desc_yml):
         move(desc_yml, desc_yaml)
+
+    # Update available commands for the model for fast bash tab completion.
+
+    info = utils.load_description(model)
+    model_cmds = set(info['commands'])
+    utils.update_completion_list(COMPLETION_COMMANDS, model_cmds)
 
     # Informative message about the size of the installed model.
     
@@ -433,6 +452,9 @@ def list_model_commands(args):
                 msg = msg.split('\n')
                 msg = ["    " + ele for ele in msg]
                 print('\n'.join(msg), end='')
+
+    # Update available commands for the model for fast bash tab completion.
+    utils.update_completion_list(COMPLETION_COMMANDS, set(info['commands']))
 
     # Suggest next step.
     

--- a/mlhub/constants.py
+++ b/mlhub/constants.py
@@ -51,6 +51,10 @@ if "MLINIT" in os.environ:
     # The following adds a trainling "/" as assumed in the code.
     MLINIT = os.path.join(os.getenv("MLINIT"), "")
 
+# Cache files for bash completion.
+COMPLETION_DIR = os.path.join(MLINIT, ".config", "completion")
+COMPLETION_COMMANDS = os.path.join(COMPLETION_DIR, "commands")
+COMPLETION_MODELS = os.path.join(COMPLETION_DIR, "models")
 
 #------------------------------------------------------------------------
 # Application information.
@@ -250,3 +254,4 @@ META_YML = "Packages.yml"
 
 debug = False
 DEBUG = "--> " + APP + ": debug: "
+

--- a/mlhub/constants.py
+++ b/mlhub/constants.py
@@ -56,6 +56,8 @@ COMPLETION_DIR = os.path.join(MLINIT, ".config", "completion")
 COMPLETION_COMMANDS = os.path.join(COMPLETION_DIR, "commands")
 COMPLETION_MODELS = os.path.join(COMPLETION_DIR, "models")
 
+COMPLETION_SCRIPT = os.path.join('bash_completion.d', 'ml.bash')
+
 #------------------------------------------------------------------------
 # Application information.
 #------------------------------------------------------------------------

--- a/mlhub/utils.py
+++ b/mlhub/utils.py
@@ -52,6 +52,9 @@ from mlhub.constants import (
     VERSION,
     APP,
     COMMANDS,
+    COMPLETION_DIR,
+    COMPLETION_COMMANDS,
+    COMPLETION_MODELS,
 )
 
 def print_usage():
@@ -64,6 +67,37 @@ def create_init():
     if not os.path.exists(MLINIT): os.makedirs(MLINIT)
 
     return(MLINIT)
+
+def update_completion_list(completion_file, new_words):
+    """Update specific completion list.
+    Args:
+        completion_file (str): full path of the completion file
+        new_words (set): set of new words
+    """
+
+    if not os.path.exists(COMPLETION_DIR):
+        os.makedirs(COMPLETION_DIR)
+
+    if os.path.exists(completion_file):
+        with open(completion_file, 'r') as file:
+            old_words = {line.strip() for line in file if line.strip()}
+
+        models = old_words | new_words
+    else:
+        models = new_words
+
+    with open(completion_file, 'w') as file:
+        file.write('\n'.join(models))
+
+def get_completion_list(completion_file):
+    """Get the list of available words from cached completion file."""
+
+    words = set()
+    if os.path.exists(completion_file):
+        with open(completion_file) as file:
+            words = {line.strip() for line in file if line.strip()}
+
+    print('\n'.join(words))
 
 def get_repo(repo):
     """Determine the repository to use: command line, environment, default."""


### PR DESCRIPTION
See pull request #36 for comparison, they are alternative solutions for the same problem of bash completion configuration.

But user will be prompted to provide sudo password when pip install:

```console
$ pip install dist/mlhub-1.4.0.tar.gz
...
Building wheels for collected packages: mlhub
  Running setup.py bdist_wheel for mlhub ... \[sudo] password for simon:
...
```