### PR TITLE
Handle malformed 'languages' field

### DIFF
--- a/mlhub/commands.py
+++ b/mlhub/commands.py
@@ -595,6 +595,14 @@ or else connect to the server's desktop using a local X server like X2Go.
     # Obtain the default/chosen language for the package.
 
     lang = desc["meta"]["languages"]
+
+    # Deal with malformed 'languages' field
+    
+    lang_opts = {"python": "py", "R": "R"}
+    for k in list(lang_opts):
+        if lang in k:
+            lang = lang_opts[k]
+            break
         
     # Obtain the specified script file.
     


### PR DESCRIPTION
If the `languages` field in the DESCRIPTION.yaml is `python` instead of `py` as below:
```yaml
--- # ResNet152 Image Object Recognition
meta:
  name         : object-recognition
  languages    : python
  version      : 1.2.0
  keywords     : image classification, python3, computer vision, imagenet, resnet, dnn, prediction, classification
  license      : gpl3
  title        : Image object recognition using resnet152.
  display      : demo, score
  author       : Graham.Williams@togaware.com
  filename     : pool/main/o/object-recognition/object-recognition_1.2.0.mlm
  date         : 2018-10-18 11:20:54
commands:
  demo  : Run the model on sample images.
  score : Run the model on images provided.
```
`ml demo object-recognition` will fail:
```console
$ ml demo object-recognition 
mlhub: The command 'demo' was not found for this model.

Try using 'commands' to list all supported commands:

  $ ml commands object-recognition
```