### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/mlhub/utils.py
+++ b/mlhub/utils.py
@@ -51,8 +51,8 @@ import yamlordereddictloader
 import zipfile
 
 from abc import ABC, abstractmethod
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process as fuzzprocess
+from rapidfuzz import fuzz
+from rapidfuzz import process as fuzzprocess
 from mlhub.constants import (
     APP,
     APPX,
@@ -2321,9 +2321,9 @@ def get_model_completion_list():
 def find_best_match(misspelled, candidates):
     """Find the best matched word with <misspelled> in <candidates>."""
 
-    best_match = fuzzprocess.extract(
+    best_match = fuzzprocess.extractOne(
         misspelled, candidates, scorer=fuzz.ratio
-    )[0]
+    )
     matched = best_match[0]
     score = best_match[1]
 

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,7 @@ setup(
     entry_points={'console_scripts': ['ml=mlhub:main']},
     install_requires=[
         'distro',
-        'fuzzywuzzy',
-        'python-Levenshtein',
+        'rapidfuzz',
         'pyyaml',
         'requests',
         'yamlordereddictloader',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy