### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-include mlhub/bash_completion.d/ml.bash
-include docs/README.md
-include LICENSE
-include mlhub/scripts/dep/python.sh
-include mlhub/scripts/dep/r.R
-include mlhub/scripts/dep/system.sh
-include mlhub/scripts/dep/mlhub.sh
-include mlhub/scripts/convert_readme.sh
-include mlhub/scripts/dep/utils.sh

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             'scripts/*.sh',
             'scripts/dep/*.sh',
             'scripts/dep/*.R'],
-    },
+    },  # See https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files
     entry_points={'console_scripts': ['ml=mlhub:main']},
     install_requires=[
         'distro',
@@ -56,6 +56,5 @@ setup(
         'pyyaml',
         'requests',
         'yamlordereddictloader',
-    ],
-    include_package_data=True,
+    ]
 )


### PR DESCRIPTION
The `MANIFEST.in` file does the same job as the [`package_data`](https://github.com/mlhubber/mlhub/blob/13416caf33d60317d209bba96739046bb2eaea5b/setup.py#L43-L50) parameter in `setup.py` and `package_data` covers all the files specified in `MANIFEST.in` and even more.
