### PR TITLE
Change on mlhub.pkg

### DIFF
--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -36,6 +36,7 @@ import getpass
 import subprocess
 import re
 import textwrap
+import platform
 from mlhub.utils import yes_or_no
 
 
@@ -255,10 +256,24 @@ def mlcat(title="", text="", delim="=", begin="", end="\n"):
 def mlpreview(fname,
               begin="\n",
               msg="Close the graphic window using Ctrl-W.\n",
-              previewer="eog"):
+              previewer=None):
     print(begin + msg)
-    subprocess.Popen([previewer, fname])
+    if is_linux():
+        if previewer is None:
+            previewer = "xdg-open" # will call linux desktop defalt application for the file
+        subprocess.Popen([previewer, fname])
+    elif is_windows():
+        os.startfile(fname) # Windows environment will automatically use defalt program based on file extension
+    else:
+        if previewer is None:
+            previewer = "open" # not having suitable platform to test available
+        subprocess.Popen([previewer, fname])
 
+def is_linux():
+    return platform.system() == "Linux"
+
+def is_windows():
+    return platform.system() == "Windows"
 
 # From Simon Zhao's azface package on github.
 

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -238,6 +238,7 @@ def mlask(begin="", end="", prompt="Press Enter to continue"):
     sys.stdout.write(begin + prompt + ": ")
     answer = input()
     sys.stdout.write(end)
+    return answer
 
 
 def mlcat(title="", text="", delim="=", begin="", end="\n"):

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -255,15 +255,16 @@ def getChar():
         return answer
 
 def mlask(begin="", end="", prompt="Press Enter to continue"):
-    begin = "\n" if len(begin) == 0 else begin
-    end = "\n" if len(end)==0 else end
-    sys.stdout.write(begin + prompt + ": ")
-    print("") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
+    begin = "\n" if begin else begin
+    end = "\n" if end else end
+    #sys.stdout.write(begin + prompt + ": ")
+    print(begin + prompt + ": ",end="") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
     answer = getChar()
     while answer != b'\r' and answer != '\n':
         answer = getChar()
-    print(" ")
-    sys.stdout.write(end)
+    print("")
+    print(end,end="")
+    # sys.stdout.write(end)
     return answer
 
 

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -264,7 +264,7 @@ def mlpreview(fname,
             previewer = "xdg-open" # will call linux desktop defalt application for the file
         subprocess.Popen([previewer, fname])
     elif is_windows():
-        os.startfile(fname) # Windows environment will automatically use defalt program based on file extension
+        subprocess.Popen(["start",fname], shell=True) # Windows environment will automatically use defalt program based on file extension
     else:
         if previewer is None:
             previewer = "open" # not having suitable platform to test available

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -262,7 +262,7 @@ def mlask(begin="", end="", prompt="Press Enter to continue"):
     answer = getChar()
     while answer != b'\r' and answer != '\n':
         answer = getChar()
-    print(" ",end="")
+    print(" ")
     sys.stdout.write(end)
     return answer
 

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -255,6 +255,8 @@ def getChar():
         return answer
 
 def mlask(begin="", end="", prompt="Press Enter to continue"):
+    begin = "\n" if len(begin) == 0 else begin
+    end = "\n" if len(end)==0 else end
     sys.stdout.write(begin + prompt + ": ")
     print("") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
     answer = getChar()

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -255,15 +255,12 @@ def getChar():
         return answer
 
 def mlask(begin="", end="", prompt="Press Enter to continue"):
-    begin = "\n" if begin else begin
-    end = "\n" if end else end
     sys.stdout.write(begin + prompt + ": ")
     print("") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
-    #answer = input()
     answer = getChar()
     while answer != b'\r' and answer != b'\n':
         answer = getChar()
-    print("")
+    print(" ",end="")
     sys.stdout.write(end)
     return answer
 

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -258,7 +258,7 @@ def mlask(begin="", end="", prompt="Press Enter to continue"):
     sys.stdout.write(begin + prompt + ": ")
     print("") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
     answer = getChar()
-    while answer != b'\r' and answer != b'\n':
+    while answer != b'\r' and answer != '\n':
         answer = getChar()
     print(" ",end="")
     sys.stdout.write(end)

--- a/mlhub/pkg.py
+++ b/mlhub/pkg.py
@@ -232,11 +232,38 @@ def azrequest(endpoint, url, subscription_key, request_data):
         raise Exception(response.text)
 
 
+def getChar():
+    # from https://stackoverflow.com/questions/510357/how-to-read-a-single-character-from-the-user
+    # try to bypass python input()
+    if is_windows():
+        # for Windows-based systems
+        import msvcrt # If successful, we are on Windows
+        return msvcrt.getch()
+    else:
+        # for POSIX-based systems (with termios & tty support)
+        import tty, sys, termios  # raises ImportError if unsupported
+
+        fd = sys.stdin.fileno()
+        oldSettings = termios.tcgetattr(fd)
+
+        try:
+            tty.setcbreak(fd)
+            answer = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, oldSettings)
+
+        return answer
+
 def mlask(begin="", end="", prompt="Press Enter to continue"):
     begin = "\n" if begin else begin
     end = "\n" if end else end
     sys.stdout.write(begin + prompt + ": ")
-    answer = input()
+    print("") # do not combine this print into the previous stdout, otherwise the stdout might show after the input
+    #answer = input()
+    answer = getChar()
+    while answer != b'\r' and answer != b'\n':
+        answer = getChar()
+    print("")
     sys.stdout.write(end)
     return answer
 


### PR DESCRIPTION
Change the behaviour of `pkg.mlask()` and `pkg.mlpreview()`, which are both crucial for current developing package.
- For `mlask`, mainly changing the waiting for Enter implementation from `input()` to an cross-platform `getChar()`, to avoid the non-response bug after `mlpreview`
- For `mlpreview`, now the defalt viewer would call system defalt application to open file.