### PR TITLE
[Fix] Internal package manager

### DIFF
--- a/mlhub/constants.py
+++ b/mlhub/constants.py
@@ -37,7 +37,7 @@ import os
 # the command line option --mlhub.
 # ------------------------------------------------------------------------
 
-MLHUB = "https://mlhub.ai/"
+MLHUB = "https://mlhub.au/"
 if "MLHUB" in os.environ:
     # The following adds a trailing "/" as assumed in the code.
     MLHUB = os.path.join(os.getenv("MLHUB"), "")


### PR DESCRIPTION
## Problem

The internal package manager is broken. For instance, running ```ml available``` command outputs the following error:

```(mlhub-39) [user]:~$ ml available
Traceback (most recent call last):
  File "/home/[user]/mlhub-39/bin/ml", line 8, in <module>
    sys.exit(main())
  File "/home/[user]/mlhub-39/lib/python3.9/site-packages/mlhub/__init__.py", line 220, in main
    args.func(args)
  File "/home/[user]/mlhub-39/lib/python3.9/site-packages/mlhub/commands.py", line 77, in list_available
    model_names = [entry["meta"]["name"] for entry in meta]
  File "/home/[user]/mlhub-39/lib/python3.9/site-packages/mlhub/commands.py", line 77, in <listcomp>
    model_names = [entry["meta"]["name"] for entry in meta]
TypeError: string indices must be integers
```

## Root Cause
I believe the project domain has changed from ```mlhub.ai``` to ```mlhub.au```, causing a mismatch in the ```MLHUB``` constant in ```constants.py```.

## Solution
- Updated the ```MLHUB``` constant in ```constants.py``` to reflect the new domain (```mlhub.au```).
- Tested the fix to ensure the ```ml available``` command and others now work as expected.